### PR TITLE
fix: Create one and only one failed alert issue for failed jobs in daily checking

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -35,16 +35,6 @@ jobs:
         run: |
           moon version --all
 
-      - name: Create an Issue for Release Failure
-        if: ${{ failure() }}
-        uses: JasonEtco/create-an-issue@v2.9.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          update_existing: true
-          search_existing: open
-          filename: .github/AUTO_ISSUE_TEMPLATE/daily-checking-fail.md
-
   setup-nightly:
     strategy:
       fail-fast: false
@@ -67,17 +57,6 @@ jobs:
       - name: Check Moonbit Version
         run: |
           moon version --all
-
-      - name: Create an Issue for Release Failure
-        if: ${{ failure() }}
-        uses: JasonEtco/create-an-issue@v2.9.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          update_existing: true
-          search_existing: open
-          filename: .github/AUTO_ISSUE_TEMPLATE/daily-checking-fail.md
-
 
   setup-bleeding:
     strategy:
@@ -102,8 +81,15 @@ jobs:
         run: |
           moon version --all
 
+  create-failure-alert:
+    needs: [setup-latest, setup-nightly, setup-bleeding]
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create an Issue for Release Failure
-        if: ${{ failure() }}
         uses: JasonEtco/create-an-issue@v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix: Create one and only one failed alert issue for failed jobs in daily checking, closes #47 