### PR TITLE
chore: Upgrade Nu to 0.105 and pin hustcer/setup-nu to v3.19

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,9 +32,9 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Nu
-      uses: hustcer/setup-nu@v3
+      uses: hustcer/setup-nu@v3.19
       with:
-        version: 0.103.0
+        version: 0.105.0
 
     - name: Setup MoonBit
       shell: nu {0}

--- a/nu/moonbit.nu
+++ b/nu/moonbit.nu
@@ -91,7 +91,7 @@ export def 'setup moonbit' [
     const IGNORE = []
     ls $MOONBIT_BIN_DIR
       | get name
-      | filter { ($in | path basename) not-in $IGNORE }
+      | where { ($in | path basename) not-in $IGNORE }
       | each { chmod +x $in }
     try { chmod +x $'($MOONBIT_BIN_DIR)/internal/tcc' } catch { print $'(ansi r)Failed to make tcc executable(ansi reset)' }
     rm moonbit*.tar.gz


### PR DESCRIPTION
chore: Upgrade Nu to 0.105 and pin hustcer/setup-nu to v3.19