### PR TITLE
fix: resolve action path at runtime so container jobs work

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,9 +39,10 @@ runs:
     - name: Setup MoonBit
       shell: nu {0}
       run: |
-        use ${{ github.action_path }}/nu/moonbit.nu *
+        # ${{ github.action_path }} expands to a host-side path that
+        # doesn't exist inside container jobs. Use $env.GITHUB_ACTION_PATH.
         let version = '${{inputs.version}}'
         let setup_core = '${{inputs.setup-core}}' | into bool
         let core_version = '${{inputs.core-version}}'
-        setup moonbit $version --setup-core=$setup_core --core-version=$core_version
+        ^nu $"($env.GITHUB_ACTION_PATH)/nu/moonbit.nu" $version $"--setup-core=($setup_core)" $"--core-version=($core_version)"
 


### PR DESCRIPTION
Container jobs fail at the `Setup MoonBit` step with `module .../moonbit.nu not found`.

`${{ github.action_path }}` is a workflow expression. GitHub Actions resolves it on the host runner and bakes in a host path like `/home/runner/work/_actions/...`. Containers mount action files at `/__w/_actions/...`, so that path is gone inside the container and `use` can't find `moonbit.nu`.

The fix drops the `use` directive and invokes `def main` from `moonbit.nu` as an external `nu` process via `$env.GITHUB_ACTION_PATH`, which resolves correctly in both runner types.

```nu
^nu $"($env.GITHUB_ACTION_PATH)/nu/moonbit.nu" $version $"--setup-core=($setup_core)" $"--core-version=($core_version)"
```
The `$"--setup-core=($setup_core)"` wrap is required because nu does not interpolate booleans inside `--flag=$var` when calling external commands. Without it, the flag arrives unset.

Tested on a downstream repo's CI. Three container jobs ([web-e2e, demo-react-e2e, canvas-e2e](https://github.com/dowdiness/canopy/actions/runs/26301739834)) pass with this fork. Diff is +3/-2 on `action.yaml`. Non-container jobs are unaffected.