### PR TITLE
test: Add container job test case for #107

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -74,3 +74,22 @@ jobs:
       - name: Check Moonbit Version
         run: |
           moon version --all
+
+  # Regression test for #107: ${{ github.action_path }} expands to a host-side
+  # path that doesn't exist inside container jobs, so the action must resolve
+  # its files via $env.GITHUB_ACTION_PATH at runtime.
+  setup-moonbit-in-container:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+    name: Setup MoonBit in Container
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Moonbit
+        uses: hustcer/setup-moonbit@develop
+
+      - name: Check Moonbit Version
+        run: |
+          moon version --all


### PR DESCRIPTION
Cover the regression fixed in dfde332: ${{ github.action_path }} points to a host path that does not exist inside container jobs, so the action must resolve files via $env.GITHUB_ACTION_PATH.