### PR TITLE
ci: Trigger basic workflow on main pushes and PRs

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -9,7 +9,13 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - develop
+  pull_request_target:
+    types:
+      - opened      # Triggers when a PR is opened
+      - reopened    # Triggers when a PR is reopened
+      - synchronize # Triggers when a commit is pushed to the PR
 
     paths-ignore:
       - '**.md'
@@ -27,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit
-        uses: hustcer/setup-moonbit@develop
+        uses: hustcer/setup-moonbit@main
 
       - name: Check Moonbit Version
         run: |
@@ -45,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit with Version
-        uses: hustcer/setup-moonbit@develop
+        uses: hustcer/setup-moonbit@main
         with:
           setup-core: false
           version: 0.9.0+9a9aff28a
@@ -66,7 +72,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit Nightly
-        uses: hustcer/setup-moonbit@develop
+        uses: hustcer/setup-moonbit@main
         with:
           version: nightly
           core-version: nightly

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -11,14 +11,12 @@ on:
     branches:
       - main
       - develop
-  pull_request_target:
-    types:
-      - opened      # Triggers when a PR is opened
-      - reopened    # Triggers when a PR is reopened
-      - synchronize # Triggers when a commit is pushed to the PR
-
+  pull_request:
     paths-ignore:
       - '**.md'
+
+permissions:
+  contents: read
 
 jobs:
   setup-moonbit:
@@ -33,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit
-        uses: hustcer/setup-moonbit@main
+        uses: ./
 
       - name: Check Moonbit Version
         run: |
@@ -51,7 +49,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit with Version
-        uses: hustcer/setup-moonbit@main
+        uses: ./
         with:
           setup-core: false
           version: 0.9.0+9a9aff28a
@@ -72,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit Nightly
-        uses: hustcer/setup-moonbit@main
+        uses: ./
         with:
           version: nightly
           core-version: nightly
@@ -101,7 +99,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Moonbit
-        uses: hustcer/setup-moonbit@main
+        uses: ./
 
       - name: Check Moonbit Version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 #   - https://github.com/marketplace/actions/checkout
 #   - https://github.com/chawyehsu/moonbit-binaries/releases
 
-name: Setup-Moonbit@Dev Basic
+name: Setup-Moonbit@CI
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Run the workflow on pushes to main and on pull_request_target events so the tests run against PRs. Also point all jobs at @main.