### PR TITLE
feat: Sync moonbit.nu with latest upstream install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./
         with:
           setup-core: false
-          version: 0.9.2+bbe2b338f
+          version: 0.10.3+16975d007
 
       - name: Check Moonbit Version
         run: |

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ In rare circumstances you might get rate limiting errors, if this happens you ca
 
 | Name         | Type     | Description                                                                                                                                       |
 | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`    | `string` | Optional, A valid moonbit tool chain version, such as `0.9.2+bbe2b338f`, `latest`, `pre-release`, or `nightly`. Defaults to `latest` or the value of `MOONBIT_INSTALL_VERSION` environment variable |
+| `version`    | `string` | Optional, A valid moonbit tool chain version, such as `0.10.3+16975d007`, `latest`, `pre-release`, or `nightly`. Defaults to `latest` or the value of `MOONBIT_INSTALL_VERSION` environment variable |
 | `setup-core` | `bool`   | Optional, Set to `true` to download and bundle Moonbit Core, `false` to skip it. Defaults to `true`                                              |
-| `core-version` | `string` | Optional, A valid moonbit core version, such as `0.9.2+bbe2b338f`, `latest`, `pre-release`, or `nightly`. Defaults to `latest` |
+| `core-version` | `string` | Optional, A valid moonbit core version, such as `0.10.3+16975d007`, `latest`, `pre-release`, or `nightly`. Defaults to `latest` |
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,9 +36,9 @@ steps:
 
 | 参数名       | 类型     | 描述                                                                                                                  |
 | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `version`    | `string` | 可选，合法的 Moonbit 工具链版本，比如：`0.9.2+bbe2b338f`、`latest`、`pre-release` 或者 `nightly`。默认为 `latest` 或环境变量 `MOONBIT_INSTALL_VERSION` 的值 |
+| `version`    | `string` | 可选，合法的 Moonbit 工具链版本，比如：`0.10.3+16975d007`、`latest`、`pre-release` 或者 `nightly`。默认为 `latest` 或环境变量 `MOONBIT_INSTALL_VERSION` 的值 |
 | `setup-core` | `bool`   | 可选，设置为 `true` 则下载并打包 Moonbit Core，`false` 则跳过。默认为 `true`                                                |
-| `core-version` | `string` | 可选，合法的 Moonbit Core 版本，比如：`0.9.2+bbe2b338f`、`latest`、`pre-release` 或者 `nightly`。默认为 `latest` |
+| `core-version` | `string` | 可选，合法的 Moonbit Core 版本，比如：`0.10.3+16975d007`、`latest`、`pre-release` 或者 `nightly`。默认为 `latest` |
 
 ## 许可
 

--- a/nu/moonbit.nu
+++ b/nu/moonbit.nu
@@ -146,18 +146,14 @@ export def 'setup moonbit' [
     rm moonbit*.tar.gz
   }
 
-  # Link AGENTS.md to moon-pilot prompt if available
-  let agents_src = $"($MOONBIT_HOME)/bin/internal/moon-pilot/lib/prompt/moonbitlang.mbt.md"
-  if ($agents_src | path exists) {
-    let agents_dst = $"($MOONBIT_HOME)/AGENTS.md"
-    if ($agents_dst | path exists) { rm -f $agents_dst }
-    if (windows?) {
-      let agents_src_win = $"($MOONBIT_HOME)\\bin\\internal\\moon-pilot\\lib\\prompt\\moonbitlang.mbt.md"
-      let agents_dst_win = $"($MOONBIT_HOME)\\AGENTS.md"
-      try { ^cmd /c mklink /H $agents_dst_win $agents_src_win } catch { print $"(ansi r)Failed to create hard link for ($agents_src_win)(ansi reset)" }
-    } else {
-      try { ^ln -sf $agents_src $agents_dst } catch { print $"(ansi r)Failed to create symlink for ($agents_src)(ansi reset)" }
-    }
+  # Link moonx to moon, matching the behavior of the official install scripts
+  if (windows?) {
+    let moonx_exe = $"($MOONBIT_BIN_DIR)\\moonx.exe"
+    if ($moonx_exe | path exists) { rm -f $moonx_exe }
+    # SymbolicLink on Windows requires elevated privileges, so use HardLink instead
+    try { ^cmd /c mklink /H $moonx_exe $"($MOONBIT_BIN_DIR)\\moon.exe" } catch { print $"(ansi r)Failed to create hard link for ($moonx_exe)(ansi reset)" }
+  } else {
+    try { ^ln -sfn moon $"($MOONBIT_BIN_DIR)/moonx" } catch { print $"(ansi r)Failed to create symlink for ($MOONBIT_BIN_DIR)/moonx(ansi reset)" }
   }
 
   print 'OS Info:'; print $nu.os-info; hr-line


### PR DESCRIPTION
Align nu/moonbit.nu with .scripts/unix.sh & powershell.ps1 on feature/latest:

- Add moonx link creation after toolchain extraction (upstream #113): a relative 'ln -sfn moon' symlink on Unix, and a hard link to moon.exe on Windows after removing any existing moonx.exe
- Drop AGENTS.md linking to the moon-pilot prompt, removed upstream (#104)